### PR TITLE
Update docs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,9 +1,9 @@
 Package: ExtendrWeb
 Title: A safe and user friendly R extension interface using Rust.
-Version: 0.2.0
+Version: 0.4.0
 Authors@R:
   c(person(given = "Andy",
-           family = "Thomason",       
+           family = "Thomason",
            role = c("aut", "cre"),
            email = "andy@andythomason.com"),
     person(given = "Mossa M.",

--- a/index.md
+++ b/index.md
@@ -11,6 +11,15 @@ The following code illustrates a simple structure trait
 which is written in Rust. The data is defined in the `struct`
 declaration and the methods in the `impl`.
 
+Extendr consists of the following projects:
+
+* [`extendr`](https://extendr.github.io/extendr) set of crates, including:
+  * [`extendr-api`](https://extendr.github.io/extendr/extendr_api) - the core Extendr crate providing all of the functionality;
+  * [`extendr-macros`](https://extendr.github.io/extendr/extendr_macros) - Extendr crate responsbile for Rust wrapper generation;
+  * [`extendr-engine`](https://extendr.github.io/extendr/extendr_engine) - crate that enables launching R sessions from Rust code;
+* [`rextendr`](https://extendr.github.io/rextendr/) - an R package that helps scaffolding extendr-enabled packages or compiling Rust code dynamically;
+* [`libR-sys`](https://extendr.github.io/libR-sys) - provides auto-generated R bindings for Rust.
+
 ```rust
 use extendr_api::prelude::*;
 

--- a/index.md
+++ b/index.md
@@ -17,8 +17,8 @@ Extendr consists of the following projects:
   * [`extendr-api`](https://extendr.github.io/extendr/extendr_api) - the core Extendr crate providing all of the functionality;
   * [`extendr-macros`](https://extendr.github.io/extendr/extendr_macros) - Extendr crate responsbile for Rust wrapper generation;
   * [`extendr-engine`](https://extendr.github.io/extendr/extendr_engine) - crate that enables launching R sessions from Rust code;
-* [`rextendr`](https://extendr.github.io/rextendr/) - an R package that helps scaffolding extendr-enabled packages or compiling Rust code dynamically;
-* [`libR-sys`](https://extendr.github.io/libR-sys) - provides auto-generated R bindings for Rust.
+* [`rextendr`](https://extendr.github.io/rextendr) - an R package that helps scaffolding extendr-enabled packages or compiling Rust code dynamically;
+* [`libR-sys`](https://extendr.github.io/libR-sys/libR_sys) - provides auto-generated R bindings for Rust.
 
 ```rust
 use extendr_api::prelude::*;

--- a/started.md
+++ b/started.md
@@ -7,8 +7,9 @@ You will then be able to call R code from Rust.
 
 ```toml
 [dependencies]
-extendr-api = "0.2"
+extendr-api = "0.4"
 ```
+
 ## Installation - R
 
 There are two ways you can use the extendr API from R. First, you can use the [rextendr](https://extendr.github.io/rextendr/) package to call individual Rust functions from an R session. Second, you can write an R package that uses compiled Rust code, see the [helloextendr](https://github.com/extendr/helloextendr) repo for a minimal example.


### PR DESCRIPTION
- Change version references to `0.4.0`
- Fix some spacing
- Add a list of references to gh pages of all primary extend repositories.