### PR TITLE
Quick start

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,17 +23,17 @@ architecture.
 
 ```
 .
-├── _quarto.yml       # Site config: navbar, sidebars, theme
-├── index.qmd         # Landing page (3 cards: Get Started, Examples, Community)
-├── get-started.qmd   # 4-step install guide (Rust, R ≥ 4.2, rextendr, rust-analyzer)
-├── changelog.qmd     # Dynamically fetches extendr CHANGELOG.md from GitHub
-├── user-guide/       # User guide
-├── intro-rust/       # Intro to Rust for R developers
-├── contributing/     # Contributor guide (style, colors, scaffolding)
-├── blog/             # Blog posts
-├── css/              # Custom SCSS
-├── images/           # Image files
-└── _extensions/      # Quarto extensions
+├── _quarto.yml            # Site config: navbar, sidebars, theme
+├── index.qmd              # Landing page (3 cards: Get Started, Examples, Community)
+├── installation-guide.qmd # 4-step install guide (Rust, R ≥ 4.2, rextendr, rust-analyzer)
+├── changelog.qmd          # Dynamically fetches extendr CHANGELOG.md from GitHub
+├── user-guide/            # User guide
+├── intro-rust/            # Intro to Rust for R developers
+├── contributing/          # Contributor guide (style, colors, scaffolding)
+├── blog/                  # Blog posts
+├── css/                   # Custom SCSS
+├── images/                # Image files
+└── _extensions/           # Quarto extensions
 ```
 
 ## Quarto (`_quarto.yml`)

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -22,7 +22,7 @@ website:
     search: true
     right:
       - text: "INSTALL"
-        href: get-started.qmd
+        href: installation-guide.qmd
       - text: DOCS
         menu:
           - text: "User Guide"

--- a/contributing/index.qmd
+++ b/contributing/index.qmd
@@ -32,5 +32,5 @@ This guide assumes the following versions of necessary software:
 - extendr-api {{< var version.extendr >}}
 - rextendr {{< var version.rextendr >}}
 
-Please see [Get Started](../get-started.qmd) if you have not already installed this 
-software.
+Please see [Installation Guide](../installation-guide.qmd) if you have not 
+already installed this software.

--- a/css/index.css
+++ b/css/index.css
@@ -32,7 +32,7 @@ body.quarto-dark #hero-header h1 {
 
 @media (min-width: 992px) {
     .hero-banner {
-        max-width: 50%;
+        max-width: 65%;
     }
 
     #hero-header p {
@@ -41,6 +41,12 @@ body.quarto-dark #hero-header h1 {
 
     #hero-header h1 {
         font-size: 3.8rem;
+    }
+}
+
+@media (min-width: 1400px) {
+    .hero-banner {
+        max-width: 50%;
     }
 }
 

--- a/index.qmd
+++ b/index.qmd
@@ -27,13 +27,29 @@ Get support for publishing to CRAN.
 ## init
 
 **Get Started** {{< iconify fluent-color:checkmark-circle-32 >}}  
-Build your first Rust-powered R package in minutes. Follow our step-by-step 
-guide or dive straight into a complete example.
+Build your first Rust-powered R package in minutes. 
 
-→ [Installation](/get-started.qmd)  
+```r
+# setup R package
+usethis::create_package("helloextendr")
+
+# add extendr scaffolding
+rextendr::use_extendr()
+
+# build and document package
+devtools::document()
+
+# call rust function
+hello_world()
+#> "Hello world!"
+```
+
+For more information, check out our installation and user guides.
+
+→ [Installation Guide](/installation-guide.qmd)  
 → [User Guide](/user-guide/index.qmd)
 
-## run example
+## ls examples/
 
 **See What's Possible** {{< iconify fluent-color:lightbulb-filament-32 >}}  
 Explore R packages built with extendr. From high-performance data processing to 
@@ -41,7 +57,7 @@ system integrations, see what the community has built.
 
 → [Browse awesome-extendr](https://github.com/extendr/awesome-extendr)
 
-## --help
+## \-\-help
 
 **Join the Community** {{< iconify fluent-color:people-interwoven-32 >}}  
 extendr has a welcoming and active community of R and Rust developers. Come ask 

--- a/installation-guide.qmd
+++ b/installation-guide.qmd
@@ -1,5 +1,5 @@
 ---
-title: "Get Started"
+title: "Installation Guide"
 toc: false
 ---
 

--- a/intro-rust/index.qmd
+++ b/intro-rust/index.qmd
@@ -44,7 +44,7 @@ what Rust developers affectionately call "The Book."
 ## Software requirements
 
 This guide assumes that you have Rust {{< var version.rust >}} installed. Please
-see [Get Started](get-started.qmd) if you do not.
+see [Installation Guide](installation-guide.qmd) if you do not.
 
 If you are not yet comfortable with installing Rust, you may find it helpful to
 try out examples in this tutorial using the open source 

--- a/user-guide/index.qmd
+++ b/user-guide/index.qmd
@@ -70,5 +70,5 @@ This guide assumes the following versions of necessary software:
 - extendr-api {{< var version.extendr >}}
 - rextendr {{< var version.rextendr >}}
 
-Please see [Get Started](../get-started.qmd) if you have not already
-installed this software.
+Please see [Installation Guide](../installation-guide.qmd) if you have not 
+already installed this software.


### PR DESCRIPTION
This PR adds a complete example to the landing page of extendr package development from start to finish. It also addresses a sizing issue with the width of the banner.

Went ahead and changed the name of the current "get started" to "Installation Guide" and fixed links and references to it in various places.

Addresses #81 and #86. 