### PR TITLE
fix: add write permission to gha

### DIFF
--- a/.github/workflows/zola.yml
+++ b/.github/workflows/zola.yml
@@ -52,6 +52,9 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
The new zola workflow needs explicit write permission for actions/deploy-pages.