### PR TITLE
fix: add scroll-margin to headings for sticky header

### DIFF
--- a/css/content.css
+++ b/css/content.css
@@ -1,13 +1,11 @@
 @layer base {
 
-    /* 
-    Typography rules for guide and blog content. The `to (.bc)` boundary stops 
-    descent into shortcode subtrees so basecoat components keep their own styling. 
-    */
+    /* The `to (.bc)` ensures basecoat components keep their own styling. */
     @scope (.content) to (.bc) {
 
         :is(h1, h2, h3, h4, h5) {
             @apply font-mono font-semibold leading-tight;
+            scroll-margin-top: calc(var(--header-h, 5rem) + 1rem);
         }
 
         h1 {


### PR DESCRIPTION
Part 2 of 5 — Zola component migration.

1. #N1 chore: fonts and lockfile
2. **#N2 fix: scroll-margin**
3. #N3 content: markdown tables
4. #N4 feat: Zola components
5. #N5 refactor: get_taxonomy

Merge in order.

---

Adds `scroll-margin-top` rule to headings, so they land clear of the sticky navbar. Could have maybe left this out until after updating components, but here it is!
