### PR TITLE
content: convert HTML tables to markdown tables and style them

### DIFF
--- a/content/blog/2026-03-25-arrow-extendr-polars/index.md
+++ b/content/blog/2026-03-25-arrow-extendr-polars/index.md
@@ -74,42 +74,12 @@ You can also find the latest version on
 This gives you the following conversions via the Arrow C Stream
 interface:
 
-<table>
-<colgroup>
-<col style="width: 19%" />
-<col style="width: 42%" />
-<col style="width: 38%" />
-</colgroup>
-<thead>
-<tr>
-<th>Type</th>
-<th>Direction</th>
-<th>R object</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><code>polars_core::frame::DataFrame</code></td>
-<td><code>IntoArrowRobj</code></td>
-<td><code>nanoarrow_array_stream</code></td>
-</tr>
-<tr>
-<td><code>polars_core::frame::DataFrame</code></td>
-<td><code>FromArrowRobj</code></td>
-<td><code>nanoarrow_array_stream</code></td>
-</tr>
-<tr>
-<td><code>polars_arrow::ffi::ArrowArrayStream</code></td>
-<td><code>IntoArrowRobj</code></td>
-<td><code>nanoarrow_array_stream</code></td>
-</tr>
-<tr>
-<td><code>polars_arrow::ffi::ArrowArrayStreamReader</code></td>
-<td><code>FromArrowRobj</code></td>
-<td><code>nanoarrow_array_stream</code></td>
-</tr>
-</tbody>
-</table>
+| Type | Direction | R object |
+| ---- | --------- | -------- |
+| `polars_core::frame::DataFrame` | `IntoArrowRobj` | `nanoarrow_array_stream` |
+| `polars_core::frame::DataFrame` | `FromArrowRobj` | `nanoarrow_array_stream` |
+| `polars_arrow::ffi::ArrowArrayStream` | `IntoArrowRobj` | `nanoarrow_array_stream` |
+| `polars_arrow::ffi::ArrowArrayStreamReader` | `FromArrowRobj` | `nanoarrow_array_stream` |
 
 ## Round-trip a Polars DataFrame through R
 

--- a/content/contributing/06-rextendr-internals.md
+++ b/content/contributing/06-rextendr-internals.md
@@ -121,6 +121,7 @@ required for CRAN submissions.
 
 ### Registration
 
+{% raw %}
 Because we are building an R package with compiled code, R requires that we
 register all routines via a C-level initialization function named
 `R_init_<pkgname>`. This is where `entrypoint.c` comes in. Currently, extendr
@@ -131,6 +132,7 @@ Rust-generated function through the R-facing `R_init_{{{mod_name}}}`. Compiling
 package next gets loaded, the C function is called to register compiled routines
 (step 6). If you inspect `R/extendr-wrappers.R`, you will see where this
 happens. The call is `@useDynLib(pkgname, .registration = TRUE)`.
+{% endraw %}
 
 ### Cleanup
 

--- a/content/contributing/06-rextendr-internals.qmd
+++ b/content/contributing/06-rextendr-internals.qmd
@@ -92,6 +92,7 @@ required for CRAN submissions.
 
 ### Registration
 
+{% raw %}
 Because we are building an R package with compiled code, R requires that we 
 register all routines via a C-level initialization function named 
 `R_init_<pkgname>`. This is where `entrypoint.c` comes in. Currently, extendr 
@@ -102,6 +103,7 @@ Rust-generated function through the R-facing `R_init_{{{mod_name}}}`. Compiling
 package next gets loaded, the C function is called to register compiled routines 
 (step 6). If you inspect `R/extendr-wrappers.R`, you will see where this 
 happens. The call is `@useDynLib(pkgname, .registration = TRUE)`.
+{% endraw %}
 
 ### Cleanup
 

--- a/content/development/collections.md
+++ b/content/development/collections.md
@@ -15,47 +15,13 @@ A `HashMap` is Rust's implementation of a hash table. It stores key-value pairs 
 
 The table below shows common HashMap types that can be used with extendr:
 
-<table>
-<colgroup>
-<col style="width: 32%" />
-<col style="width: 29%" />
-<col style="width: 37%" />
-</colgroup>
-<thead>
-<tr>
-<th>R type</th>
-<th>Rust type</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><code>list(a = 1L, b = 2L)</code></td>
-<td><code>HashMap&lt;String, i32&gt;</code></td>
-<td>Named list with integer values</td>
-</tr>
-<tr>
-<td><code>list(a = 1.0, b = 2.0)</code></td>
-<td><code>HashMap&lt;String, f64&gt;</code></td>
-<td>Named list with double values</td>
-</tr>
-<tr>
-<td><code>list(a = "x", b = "y")</code></td>
-<td><code>HashMap&lt;String, String&gt;</code></td>
-<td>Named list with character values</td>
-</tr>
-<tr>
-<td><code>list(a = TRUE, b = FALSE)</code></td>
-<td><code>HashMap&lt;String, bool&gt;</code></td>
-<td>Named list with logical values</td>
-</tr>
-<tr>
-<td><code>list(a = list(), b = 1)</code></td>
-<td><code>HashMap&lt;String, Robj&gt;</code></td>
-<td>Named list with mixed types</td>
-</tr>
-</tbody>
-</table>
+| R type                          | Rust type                    | Description                          |
+|---------------------------------|------------------------------|--------------------------------------|
+| `list(a = 1L, b = 2L)`          | `HashMap<String, i32>`       | Named list with integer values       |
+| `list(a = 1.0, b = 2.0)`        | `HashMap<String, f64>`       | Named list with double values        |
+| `list(a = "x", b = "y")`        | `HashMap<String, String>`    | Named list with character values     |
+| `list(a = TRUE, b = FALSE)`     | `HashMap<String, bool>`      | Named list with logical values       |
+| `list(a = list(), b = 1)`       | `HashMap<String, Robj>`      | Named list with mixed types          |
 
 {% callout(type="warning") %}
 There are two important behaviors to be aware of when using HashMaps with R lists:

--- a/content/development/data-types.md
+++ b/content/development/data-types.md
@@ -13,29 +13,27 @@ The below lists the extendr structs that wrap R object types. These types can be
 
 R has no concept of scalar values whereas Rust does. Rust does not have the concept of an NA. As such, we have types to represent scalar values in R. The below is how they are mapped.
 
-{% raw_table(format="csv") %}
-R, Rust, extendr
-integer(1), i32, Rint
-logical(1), bool, Rbool
-double(1), f64, Rfloat
-complex(1), Complex<f64>, Rcplx
-character(1), String, Rstr
-{% end %}
+| R              | Rust           | extendr  |
+|----------------|----------------|----------|
+| `integer(1)`   | `i32`          | `Rint`   |
+| `logical(1)`   | `bool`         | `Rbool`  |
+| `double(1)`    | `f64`          | `Rfloat` |
+| `complex(1)`   | `Complex<f64>` | `Rcplx`  |
+| `character(1)` | `String`       | `Rstr`   |
 
 ## Vector types
 
 Everything in R is a vector. In Rust, we have to point to R's owned vector types rather than use Rust's native `Vec` collection. These are mapped accordingly:
 
-{% raw_table(format="csv") %}
-R,extendr,scalar,C API
-integer(),Integers,Rint,INTSXP
-double(),Doubles,Rfloat,REALSXP
-logical(),Logicals,Rbool,LGLSXP
-complex(),Complexes,Rcplx,CPLXSXP
-character(),Strings,Rstr,STRSXP
-raw(),Raw,&\[u8\],RAWSXP
-list(),List,Robj,VECSXP
-{% end %}
+| R             | extendr     | scalar   | C API     |
+|---------------|-------------|----------|-----------|
+| `integer()`   | `Integers`  | `Rint`   | `INTSXP`  |
+| `double()`    | `Doubles`   | `Rfloat` | `REALSXP` |
+| `logical()`   | `Logicals`  | `Rbool`  | `LGLSXP`  |
+| `complex()`   | `Complexes` | `Rcplx`  | `CPLXSXP` |
+| `character()` | `Strings`   | `Rstr`   | `STRSXP`  |
+| `raw()`       | `Raw`       | `&[u8]`  | `RAWSXP`  |
+| `list()`      | `List`      | `Robj`   | `VECSXP`  |
 
 ## Using Rust library types vs R-native types
 

--- a/content/development/data-types.qmd
+++ b/content/development/data-types.qmd
@@ -12,30 +12,27 @@ The below lists the extendr structs that wrap R object types. These types can be
 
 R has no concept of scalar values whereas Rust does. Rust does not have the concept of an NA. As such, we have types to represent scalar values in R. The below is how they are mapped. 
 
-{% raw_table(format="csv") %}
-R, Rust, extendr
-integer(1), i32, Rint
-logical(1), bool, Rbool
-double(1), f64, Rfloat
-complex(1), Complex<f64>, Rcplx
-character(1), String, Rstr
-{% end %}
+| R              | Rust           | extendr  |
+|----------------|----------------|----------|
+| `integer(1)`   | `i32`          | `Rint`   |
+| `logical(1)`   | `bool`         | `Rbool`  |
+| `double(1)`    | `f64`          | `Rfloat` |
+| `complex(1)`   | `Complex<f64>` | `Rcplx`  |
+| `character(1)` | `String`       | `Rstr`   |
 
 ## Vector types
 
 Everything in R is a vector. In Rust, we have to point to R's owned vector types rather than use Rust's native `Vec` collection. These are mapped accordingly:
 
-{% raw_table(format="csv") %}
-R,extendr,scalar,C API
-integer(),Integers,Rint,INTSXP
-double(),Doubles,Rfloat,REALSXP
-logical(),Logicals,Rbool,LGLSXP
-complex(),Complexes,Rcplx,CPLXSXP
-character(),Strings,Rstr,STRSXP
-raw(),Raw,&[u8],RAWSXP
-list(),List,Robj,VECSXP
-{% end %}
-
+| R             | extendr     | scalar   | C API     |
+|---------------|-------------|----------|-----------|
+| `integer()`   | `Integers`  | `Rint`   | `INTSXP`  |
+| `double()`    | `Doubles`   | `Rfloat` | `REALSXP` |
+| `logical()`   | `Logicals`  | `Rbool`  | `LGLSXP`  |
+| `complex()`   | `Complexes` | `Rcplx`  | `CPLXSXP` |
+| `character()` | `Strings`   | `Rstr`   | `STRSXP`  |
+| `raw()`       | `Raw`       | `&[u8]`  | `RAWSXP`  |
+| `list()`      | `List`      | `Robj`   | `VECSXP`  |
 
 ## Using Rust library types vs R-native types
 

--- a/content/publishing/cran-msrv.md
+++ b/content/publishing/cran-msrv.md
@@ -21,19 +21,18 @@ the extendr package [`{fio}`](https://albersonmiranda.github.io/fio/).
 
 **CRAN's MSRV** is 1.91.1.
 
-{% raw_table(format="csv") %}
-"Check flavor","rustc","cargo"
-"r-oldrel-macos-arm64",1.91.1,1.91.1
-"r-devel-windows-x86_64",1.92.0,1.92.0
-"r-release-windows-x86_64",1.92.0,1.92.0
-"r-oldrel-windows-x86_64",1.92.0,1.92.0
-"r-release-macos-arm64",1.93.0,1.93.0
-"r-release-macos-x86_64",1.93.0,1.93.0
-"r-oldrel-macos-x86_64",1.93.0,1.93.0
-"r-devel-linux-x86_64-fedora-clang",1.93.1,1.93.1
-"r-devel-linux-x86_64-fedora-gcc",1.93.1,1.93.1
-"r-devel-linux-x86_64-debian-clang",1.94.1,1.94.1
-"r-devel-linux-x86_64-debian-gcc",1.94.1,1.94.1
-"r-patched-linux-x86_64",1.94.1,1.94.1
-"r-release-linux-x86_64",1.94.1,1.94.1
-{% end %}
+| Check flavor                      | rustc  | cargo  |
+|:----------------------------------|:-------|:-------|
+| r-oldrel-macos-arm64              | 1.91.1 | 1.91.1 |
+| r-devel-windows-x86_64            | 1.92.0 | 1.92.0 |
+| r-release-windows-x86_64          | 1.92.0 | 1.92.0 |
+| r-oldrel-windows-x86_64           | 1.92.0 | 1.92.0 |
+| r-release-macos-arm64             | 1.93.0 | 1.93.0 |
+| r-release-macos-x86_64            | 1.93.0 | 1.93.0 |
+| r-oldrel-macos-x86_64             | 1.93.0 | 1.93.0 |
+| r-devel-linux-x86_64-debian-clang | 1.95.0 | 1.95.0 |
+| r-devel-linux-x86_64-debian-gcc   | 1.95.0 | 1.95.0 |
+| r-patched-linux-x86_64            | 1.95.0 | 1.95.0 |
+| r-release-linux-x86_64            | 1.95.0 | 1.95.0 |
+| r-devel-linux-x86_64-fedora-clang | 1.97.1 | 1.97.1 |
+| r-devel-linux-x86_64-fedora-gcc   | 1.97.1 | 1.97.1 |

--- a/content/publishing/cran-msrv.qmd
+++ b/content/publishing/cran-msrv.qmd
@@ -76,11 +76,5 @@ res <- res[order(res[["rustc"]]), ]
 ```{r}
 #| echo: false
 #| results: asis
-csv_string <- capture.output(write.csv(res, row.names = FALSE))
-cat(
-  '{% raw_table(format="csv") %}',
-  csv_string,
-  "{% end %}",
-  sep = "\n"
-)
+knitr::kable(res, row.names = FALSE)
 ```

--- a/css/content.css
+++ b/css/content.css
@@ -48,5 +48,29 @@
         a {
             @apply text-link hover:text-link-hover hover:underline;
         }
+
+        table {
+            @apply w-full caption-bottom text-sm my-6;
+
+            thead {
+                @apply [&_tr]:border-b;
+            }
+
+            tbody {
+                @apply [&>tr:not(:last-child)]:border-none [&>tr:last-child]:border-b;
+
+                tr {
+                    @apply hover:bg-muted/100 transition-colors;
+                }
+            }
+
+            th {
+                @apply text-foreground h-8 px-2 text-left align-middle font-medium;
+            }
+
+            td {
+                @apply p-2 align-middle;
+            }
+        }
     }
 }


### PR DESCRIPTION
Part 3 of 5 — Zola component migration.

1. #N1 chore: fonts and lockfile
2. #N2 fix: scroll-margin
3. **#N3 content: markdown tables**
4. #N4 feat: Zola components
5. #N5 refactor: get_taxonomy

Merge in order.

---

Zola supports pipe tables, so a lot of the clunky machinery I added was unnecessary.

Removes the `raw_table` and `load_table` shortcodes ahead of #N4 by converting their consumers to plain markdown tables, and adds a `table` block to `css/content.css` so bare markdown tables pick up the basecoat styling the shortcodes used to apply.

- convert all HTML/CSV tables to pipe tables
- `cran-msrv.qmd` now emits via `knitr::kable()` instead of building a `raw_table` shortcode call. MSRV numbers shift because the chunk re-ran against current CRAN data.
- Wraps the `R_init_{{{mod_name}}}` passage in `06-rextendr-internals` in `{% raw %}` so Zola stops parsing it as template syntax.